### PR TITLE
ROS-296: Now uses TransliterationResults to hold language mappings, a…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 script: mvn verify
 jdk:
 - oraclejdk8
-- oraclejdk7
 - openjdk7
 notifications:
   slack:

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.102</version>
+        <version>2.3.104-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.100</version>
     </parent>
     <dependencies>
         <dependency>

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.100</version>
+        <version>2.3.102</version>
     </parent>
     <dependencies>
         <dependency>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.100</version>
     </parent>
     <build>
         <resources>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.102</version>
+        <version>2.3.104-SNAPSHOT</version>
     </parent>
     <build>
         <resources>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.100</version>
+        <version>2.3.102</version>
     </parent>
     <build>
         <resources>

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedDataModelModule.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedDataModelModule.java
@@ -21,6 +21,7 @@ import com.basistech.rosette.dm.Attribute;
 import com.basistech.rosette.dm.BaseAttribute;
 import com.basistech.rosette.dm.BaseNounPhrase;
 import com.basistech.rosette.dm.CategorizerResult;
+import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.Dependency;
 import com.basistech.rosette.dm.EmbeddingCollection;
 import com.basistech.rosette.dm.Embeddings;
@@ -40,9 +41,10 @@ import com.basistech.rosette.dm.RelationshipMention;
 import com.basistech.rosette.dm.ScriptRegion;
 import com.basistech.rosette.dm.Sentence;
 import com.basistech.rosette.dm.Token;
-import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.TranslatedData;
 import com.basistech.rosette.dm.TranslatedTokens;
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.rosette.dm.TransliterationResults;
 import com.basistech.util.jackson.EnumModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -92,6 +94,8 @@ public class  AnnotatedDataModelModule extends EnumModule {
         context.setMixInAnnotations(Embeddings.class, EmbeddingsMixin.class);
         context.setMixInAnnotations(Concept.class, ConceptMixin.class);
         context.setMixInAnnotations(Keyphrase.class, KeyphraseMixin.class);
+        context.setMixInAnnotations(Transliteration.class, TransliterationMixin.class);
+        context.setMixInAnnotations(TransliterationResults.class, TransliterationResultsMixin.class);
 
         // type-serializers
         SimpleSerializers serializers = new SimpleSerializers();

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedDataModelModule.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedDataModelModule.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedTextMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedTextMixin.java
@@ -18,6 +18,7 @@ package com.basistech.rosette.dm.jackson;
 import com.basistech.rosette.dm.BaseAttribute;
 import com.basistech.rosette.dm.BaseNounPhrase;
 import com.basistech.rosette.dm.CategorizerResult;
+import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.Dependency;
 import com.basistech.rosette.dm.Embeddings;
 import com.basistech.rosette.dm.Entity;
@@ -28,9 +29,9 @@ import com.basistech.rosette.dm.RelationshipMention;
 import com.basistech.rosette.dm.ScriptRegion;
 import com.basistech.rosette.dm.Sentence;
 import com.basistech.rosette.dm.Token;
-import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.TranslatedData;
 import com.basistech.rosette.dm.TranslatedTokens;
+import com.basistech.rosette.dm.TransliterationResults;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -132,4 +133,7 @@ public abstract class AnnotatedTextMixin {
 
     @JsonIgnore
     public abstract ListAttribute<Keyphrase> getKeyphrases();
+
+    @JsonIgnore
+    public abstract TransliterationResults getTransliteration();
 }

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedTextMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/AnnotatedTextMixin.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/KnownAttribute.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/KnownAttribute.java
@@ -32,6 +32,7 @@ import com.basistech.rosette.dm.Token;
 import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.TranslatedData;
 import com.basistech.rosette.dm.TranslatedTokens;
+import com.basistech.rosette.dm.TransliterationResults;
 import com.basistech.rosette.dm.UnknownAttribute;
 
 /**
@@ -63,7 +64,8 @@ public enum KnownAttribute {
     UNKNOWN("unknown", UnknownAttribute.class),
     RELATION_ARGUMENT("RelationshipComponent", RelationshipComponent.class),
     CONCEPT("concept", Concept.class),
-    KEYPHRASE("keyphrase", Keyphrase.class);
+    KEYPHRASE("keyphrase", Keyphrase.class),
+    TRANSLITERATION("transliteration", TransliterationResults.class);
 
     private final String jsonTag;
     private final Class<? extends BaseAttribute> attributeClass;

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/KnownAttribute.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/KnownAttribute.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationMixin.java
@@ -1,0 +1,31 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class TransliterationMixin {
+    @JsonCreator
+    TransliterationMixin(
+            @JsonProperty("scriptMap") Map<String, String> scriptMap,
+            @JsonProperty("extendedProperties") Map<String, Object> extendedProperties) {
+        //
+    }
+}

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationMixin.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
@@ -1,0 +1,49 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm.jackson;
+
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.util.LanguageCode;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransliterationResultsDeserializer extends JsonDeserializer<Map<LanguageCode, Transliteration>> {
+    private static final TypeReference<Map<String, Map<String, String>>> REF =
+            new TypeReference<Map<String, Map<String, String>>>() { };
+    @Override
+    public Map<LanguageCode, Transliteration> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+        Map<String, Map<String, String>> val = p.readValueAs(REF);
+        Map<LanguageCode, Transliteration> output = new HashMap<>();
+        for (String key : val.keySet()) {
+            Map<String, String> forLang = val.get(key);
+            Transliteration.Builder b = new Transliteration.Builder();
+            b.transliterations(forLang);
+            output.put(LanguageCode.lookupByISO639(key), b.build());
+        }
+
+        return output;
+    }
+}

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
@@ -17,6 +17,7 @@
 package com.basistech.rosette.dm.jackson;
 
 import com.basistech.rosette.dm.Transliteration;
+import com.basistech.util.ISO15924;
 import com.basistech.util.LanguageCode;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,16 +30,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TransliterationResultsDeserializer extends JsonDeserializer<Map<LanguageCode, Transliteration>> {
-    private static final TypeReference<Map<String, Map<String, String>>> REF =
-            new TypeReference<Map<String, Map<String, String>>>() { };
+    private static final TypeReference<Map<String, Map<ISO15924, String>>> REF =
+            new TypeReference<Map<String, Map<ISO15924, String>>>() { };
     @Override
     public Map<LanguageCode, Transliteration> deserialize(JsonParser p, DeserializationContext ctxt)
             throws IOException, JsonProcessingException {
 
-        Map<String, Map<String, String>> val = p.readValueAs(REF);
+        Map<String, Map<ISO15924, String>> val = p.readValueAs(REF);
         Map<LanguageCode, Transliteration> output = new HashMap<>();
         for (String key : val.keySet()) {
-            Map<String, String> forLang = val.get(key);
+            Map<ISO15924, String> forLang = val.get(key);
             Transliteration.Builder b = new Transliteration.Builder();
             b.transliterations(forLang);
             output.put(LanguageCode.lookupByISO639(key), b.build());

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsDeserializer.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +38,10 @@ public class TransliterationResultsDeserializer extends JsonDeserializer<Map<Lan
 
         Map<String, Map<ISO15924, String>> val = p.readValueAs(REF);
         Map<LanguageCode, Transliteration> output = new HashMap<>();
-        for (String key : val.keySet()) {
-            Map<ISO15924, String> forLang = val.get(key);
+        for (Map.Entry<String, Map<ISO15924, String>> entry : val.entrySet()) {
             Transliteration.Builder b = new Transliteration.Builder();
-            b.transliterations(forLang);
-            output.put(LanguageCode.lookupByISO639(key), b.build());
+            b.transliterations(entry.getValue());
+            output.put(LanguageCode.lookupByISO639(entry.getKey()), b.build());
         }
 
         return output;

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
@@ -1,0 +1,40 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm.jackson;
+
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.util.LanguageCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.Map;
+
+public abstract class TransliterationResultsMixin {
+
+    @JsonDeserialize(using = TransliterationResultsDeserializer.class)
+    @JsonSerialize(using = TransliterationResultsSerializer.class)
+    Map<LanguageCode, Transliteration> transliterationResults;
+
+    @JsonCreator
+    TransliterationResultsMixin(
+            @JsonProperty("transliterationResults") Map<LanguageCode, Transliteration> transliterationResults,
+            @JsonProperty("extendedProperties") Map<String, Object> extendedProperties) {
+        //
+    }
+}

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
@@ -29,11 +29,11 @@ public abstract class TransliterationResultsMixin {
 
     @JsonDeserialize(using = TransliterationResultsDeserializer.class)
     @JsonSerialize(using = TransliterationResultsSerializer.class)
-    Map<LanguageCode, Transliteration> transliterationResults;
+    Map<LanguageCode, Transliteration> results;
 
     @JsonCreator
     TransliterationResultsMixin(
-            @JsonProperty("transliterationResults") Map<LanguageCode, Transliteration> transliterationResults,
+            @JsonProperty("results") Map<LanguageCode, Transliteration> results,
             @JsonProperty("extendedProperties") Map<String, Object> extendedProperties) {
         //
     }

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsMixin.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
@@ -1,0 +1,39 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm.jackson;
+
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.util.LanguageCode;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class TransliterationResultsSerializer extends JsonSerializer<Map<LanguageCode, Transliteration>> {
+    @Override
+    public void serialize(Map<LanguageCode, Transliteration> value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException, JsonProcessingException {
+        gen.writeStartObject();
+        for (LanguageCode key : value.keySet()) {
+            gen.writeObjectField(key.ISO639_3(), value.get(key).getAllTransliterations());
+        }
+        gen.writeEndObject();
+    }
+}

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TransliterationResultsSerializer.java
@@ -32,7 +32,7 @@ public class TransliterationResultsSerializer extends JsonSerializer<Map<Languag
             throws IOException, JsonProcessingException {
         gen.writeStartObject();
         for (LanguageCode key : value.keySet()) {
-            gen.writeObjectField(key.ISO639_3(), value.get(key).getAllTransliterations());
+            gen.writeObjectField(key.ISO639_3(), value.get(key).getAll());
         }
         gen.writeEndObject();
     }

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/array/AnnotatedDataModelArrayModule.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/array/AnnotatedDataModelArrayModule.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/array/AnnotatedDataModelArrayModule.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/array/AnnotatedDataModelArrayModule.java
@@ -44,6 +44,8 @@ import com.basistech.rosette.dm.Token;
 import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.TranslatedData;
 import com.basistech.rosette.dm.TranslatedTokens;
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.rosette.dm.TransliterationResults;
 import com.basistech.rosette.dm.jackson.ArabicMorphoAnalysisMixin;
 import com.basistech.rosette.dm.jackson.AttributeMixin;
 import com.basistech.rosette.dm.jackson.BaseNounPhraseMixin;
@@ -69,6 +71,8 @@ import com.basistech.rosette.dm.jackson.SentenceMixin;
 import com.basistech.rosette.dm.jackson.ConceptMixin;
 import com.basistech.rosette.dm.jackson.TranslatedDataMixin;
 import com.basistech.rosette.dm.jackson.TranslatedTokensMixin;
+import com.basistech.rosette.dm.jackson.TransliterationMixin;
+import com.basistech.rosette.dm.jackson.TransliterationResultsMixin;
 import com.basistech.util.jackson.EnumModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 /**
@@ -120,6 +124,8 @@ public class AnnotatedDataModelArrayModule extends EnumModule {
         context.setMixInAnnotations(Embeddings.class, EmbeddingsMixin.class);
         context.setMixInAnnotations(Concept.class, ConceptMixin.class);
         context.setMixInAnnotations(Keyphrase.class, KeyphraseMixin.class);
+        context.setMixInAnnotations(Transliteration.class, TransliterationMixin.class);
+        context.setMixInAnnotations(TransliterationResults.class, TransliterationResultsMixin.class);
     }
 
     /**

--- a/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
@@ -381,7 +381,8 @@ public class JsonTest extends AdmAssert {
         objectWriter.writeValue(writer, referenceText);
         // to tell that the version is there, we read as a tree
         JsonNode tree = mapper.readTree(writer.toString());
-        assertEquals("1.1.0", tree.get(4).asText());
+        // Property is injected at the end.
+        assertEquals("1.1.0", tree.get(tree.size() - 1).asText());
     }
 
     @Test

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
@@ -329,12 +329,12 @@ public class JsonTest extends AdmAssert {
 
         TransliterationResults.Builder transliterationBuilder =
                 new TransliterationResults.Builder(LanguageCode.ENGLISH,
-                        "Latn",
+                        ISO15924.Latn,
                         THIS_IS_THE_TERRIER_SHOT_TO_BOSTON);
 
         // Translation: This is the terrier shot to boston
         transliterationBuilder.addTransliteration(
-                LanguageCode.ARABIC, Transliteration.of("Arab", "هذا هو النار ضربة الى بوسطن."));
+                LanguageCode.ARABIC, Transliteration.of(ISO15924.Arab, "هذا هو النار ضربة الى بوسطن."));
 
         builder.transliteration(transliterationBuilder.build());
 
@@ -557,11 +557,11 @@ public class JsonTest extends AdmAssert {
 
         TransliterationResults.Builder transliterationBuilder =
                 new TransliterationResults.Builder(LanguageCode.ENGLISH,
-                        "Latn",
+                        ISO15924.Latn,
                         THIS_IS_THE_TERRIER_SHOT_TO_BOSTON);
 
         transliterationBuilder.addTransliteration(
-                LanguageCode.ARABIC, Transliteration.of("Arab", THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC));
+                LanguageCode.ARABIC, Transliteration.of(ISO15924.Arab, THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC));
 
         builder.transliteration(transliterationBuilder.build());
 
@@ -726,11 +726,11 @@ public class JsonTest extends AdmAssert {
 
         Transliteration engTransliteration =
                 read.getTransliteration().getTransliteration(LanguageCode.ENGLISH);
-        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.getWithScript("Latn"));
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.get(ISO15924.Latn));
 
         Transliteration araTransliteration =
                 read.getTransliteration().getTransliteration(LanguageCode.ARABIC);
-        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.getWithScript("Arab"));
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.get(ISO15924.Arab));
 
     }
 
@@ -815,11 +815,11 @@ public class JsonTest extends AdmAssert {
 
         Transliteration engTransliteration =
                 read.getTransliteration().getTransliteration(LanguageCode.ENGLISH);
-        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.getWithScript("Latn"));
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.get(ISO15924.Latn));
 
         Transliteration araTransliteration =
                 read.getTransliteration().getTransliteration(LanguageCode.ARABIC);
-        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.getWithScript("Arab"));
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.get(ISO15924.Arab));
     }
 
     @Test

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -334,7 +334,7 @@ public class JsonTest extends AdmAssert {
 
         // Translation: This is the terrier shot to boston
         transliterationBuilder.addTransliteration(
-                LanguageCode.ARABIC, Transliteration.of(ISO15924.Arab, "هذا هو النار ضربة الى بوسطن."));
+                LanguageCode.ARABIC, Transliteration.of(ISO15924.Arab, THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC));
 
         builder.transliteration(transliterationBuilder.build());
 

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
@@ -41,6 +41,8 @@ import com.basistech.rosette.dm.Token;
 import com.basistech.rosette.dm.Concept;
 import com.basistech.rosette.dm.TranslatedData;
 import com.basistech.rosette.dm.TranslatedTokens;
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.rosette.dm.TransliterationResults;
 import com.basistech.rosette.dm.jackson.AnnotatedDataModelModule;
 import com.basistech.util.ISO15924;
 import com.basistech.util.LanguageCode;
@@ -73,6 +75,7 @@ import java.util.Set;
 public class JsonTest extends AdmAssert {
 
     private static final String THIS_IS_THE_TERRIER_SHOT_TO_BOSTON = "This is the terrier shot to Boston.";
+    private static final String THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC = "هذا هو النار ضربة الى بوسطن.";
     private BaseNounPhrase baseNounPhrase;
     private com.basistech.rosette.dm.EntityMention entityMention;
     private RelationshipMention relationshipMention;
@@ -324,6 +327,17 @@ public class JsonTest extends AdmAssert {
         keyphraseBuilder.add(keyphrase);
         builder.keyphrases(keyphraseBuilder.build());
 
+        TransliterationResults.Builder transliterationBuilder =
+                new TransliterationResults.Builder(LanguageCode.ENGLISH,
+                        "Latn",
+                        THIS_IS_THE_TERRIER_SHOT_TO_BOSTON);
+
+        // Translation: This is the terrier shot to boston
+        transliterationBuilder.addTransliteration(
+                LanguageCode.ARABIC, Transliteration.of("Arab", "هذا هو النار ضربة الى بوسطن."));
+
+        builder.transliteration(transliterationBuilder.build());
+
         referenceTextOldEntities = builder.build();
 
     }
@@ -541,6 +555,16 @@ public class JsonTest extends AdmAssert {
         embeddings = embeddingsBuilder.build();
         builder.embeddings(embeddingsBuilder.build());
 
+        TransliterationResults.Builder transliterationBuilder =
+                new TransliterationResults.Builder(LanguageCode.ENGLISH,
+                        "Latn",
+                        THIS_IS_THE_TERRIER_SHOT_TO_BOSTON);
+
+        transliterationBuilder.addTransliteration(
+                LanguageCode.ARABIC, Transliteration.of("Arab", THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC));
+
+        builder.transliteration(transliterationBuilder.build());
+
         referenceText = builder.build();
 
 
@@ -699,6 +723,15 @@ public class JsonTest extends AdmAssert {
         assertEquals(sentimentResult, read.getSentimentResults().get(0));
 
         assertEquals(topicResult, read.getTopicResults().get(0));
+
+        Transliteration engTransliteration =
+                read.getTransliteration().getTransliteration(LanguageCode.ENGLISH);
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.getWithScript("Latn"));
+
+        Transliteration araTransliteration =
+                read.getTransliteration().getTransliteration(LanguageCode.ARABIC);
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.getWithScript("Arab"));
+
     }
 
     @Test
@@ -779,6 +812,14 @@ public class JsonTest extends AdmAssert {
 
         Embeddings readEmbeddings = read.getEmbeddings();
         assertEquals(embeddings, readEmbeddings);
+
+        Transliteration engTransliteration =
+                read.getTransliteration().getTransliteration(LanguageCode.ENGLISH);
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON, engTransliteration.getWithScript("Latn"));
+
+        Transliteration araTransliteration =
+                read.getTransliteration().getTransliteration(LanguageCode.ARABIC);
+        assertEquals(THIS_IS_THE_TERRIER_SHOT_TO_BOSTON_ARABIC, araTransliteration.getWithScript("Arab"));
     }
 
     @Test

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
@@ -19,6 +19,7 @@ package com.basistech.rosette.dm.json.plain;
 import com.basistech.rosette.dm.Transliteration;
 import com.basistech.rosette.dm.TransliterationResults;
 import com.basistech.rosette.dm.jackson.AnnotatedDataModelModule;
+import com.basistech.util.ISO15924;
 import com.basistech.util.LanguageCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
@@ -50,7 +51,7 @@ public class TransliterationResultsTest {
     public void testClear() throws IOException {
         TransliterationResults empty = builder().build();
         TransliterationResults hopefullyEmpty = builder()
-                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", "Some stuff"))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of(ISO15924.Latn, "Some stuff"))
                 .clearResults()
                 .build();
         assertEquals(empty, throughString(hopefullyEmpty));
@@ -61,18 +62,18 @@ public class TransliterationResultsTest {
         String one = "some stuff";
         String two = "other stuff";
         TransliterationResults t = builder()
-                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", one))
-                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Arab", two))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of(ISO15924.Latn, one))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of(ISO15924.Arab, two))
                 .build();
         assertEquals(t, throughString(t));
 
         assertEquals(ImmutableSet.of(LanguageCode.ARABIC), t.getResults().keySet());
 
-        assertEquals(ImmutableSet.of("Latn", "Arab"),
+        assertEquals(ImmutableSet.of(ISO15924.Latn, ISO15924.Arab),
                 t.getTransliteration(LanguageCode.ARABIC).listScripts());
 
-        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, "Latn"));
-        assertEquals(two, t.getTransliterationInScript(LanguageCode.ARABIC, "Arab"));
+        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, ISO15924.Latn));
+        assertEquals(two, t.getTransliterationInScript(LanguageCode.ARABIC, ISO15924.Arab));
 
     }
 
@@ -81,21 +82,21 @@ public class TransliterationResultsTest {
         String one = "some stuff";
         String two = "other stuff";
         TransliterationResults t = builder()
-                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", one))
-                .addTransliteration(LanguageCode.AFRIKAANS, Transliteration.of("Arab", two))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of(ISO15924.Latn, one))
+                .addTransliteration(LanguageCode.AFRIKAANS, Transliteration.of(ISO15924.Arab, two))
                 .build();
         assertEquals(t, throughString(t));
 
         assertEquals(ImmutableSet.of(LanguageCode.ARABIC, LanguageCode.AFRIKAANS), t.getResults().keySet());
 
-        assertEquals(ImmutableSet.of("Latn"), t.getTransliteration(LanguageCode.ARABIC).listScripts());
+        assertEquals(ImmutableSet.of(ISO15924.Latn), t.getTransliteration(LanguageCode.ARABIC).listScripts());
 
-        assertEquals(ImmutableSet.of("Arab"),
+        assertEquals(ImmutableSet.of(ISO15924.Arab),
                 t.getTransliteration(LanguageCode.AFRIKAANS).listScripts());
 
 
-        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, "Latn"));
-        assertEquals(two, t.getTransliterationInScript(LanguageCode.AFRIKAANS, "Arab"));
+        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, ISO15924.Latn));
+        assertEquals(two, t.getTransliterationInScript(LanguageCode.AFRIKAANS, ISO15924.Arab));
 
     }
 

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
@@ -1,0 +1,102 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm.json.plain;
+
+import com.basistech.rosette.dm.Transliteration;
+import com.basistech.rosette.dm.TransliterationResults;
+import com.basistech.rosette.dm.jackson.AnnotatedDataModelModule;
+import com.basistech.util.LanguageCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TransliterationResultsTest {
+
+    private static final ObjectMapper OBJ_MAP = AnnotatedDataModelModule.setupObjectMapper(new ObjectMapper());
+
+    private TransliterationResults throughString(TransliterationResults t) throws IOException {
+        return OBJ_MAP.readValue(OBJ_MAP.writeValueAsString(t), TransliterationResults.class);
+    }
+
+    private TransliterationResults.Builder builder() {
+        return new TransliterationResults.Builder();
+    }
+
+    @Test
+    public void testEmpty() throws IOException {
+        TransliterationResults t = builder().build();
+        assertEquals(t, throughString(t));
+    }
+
+    @Test
+    public void testClear() throws IOException {
+        TransliterationResults empty = builder().build();
+        TransliterationResults hopefullyEmpty = builder()
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", "Some stuff"))
+                .clearResults()
+                .build();
+        assertEquals(empty, throughString(hopefullyEmpty));
+    }
+
+    @Test
+    public void testTwoInOne() throws IOException {
+        String one = "some stuff";
+        String two = "other stuff";
+        TransliterationResults t = builder()
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", one))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Arab", two))
+                .build();
+        assertEquals(t, throughString(t));
+
+        assertEquals(ImmutableSet.of(LanguageCode.ARABIC), t.getTransliterationResults().keySet());
+
+        assertEquals(ImmutableSet.of("Latn", "Arab"),
+                t.getTransliteration(LanguageCode.ARABIC).listScripts());
+
+        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, "Latn"));
+        assertEquals(two, t.getTransliterationInScript(LanguageCode.ARABIC, "Arab"));
+
+    }
+
+    @Test
+    public void testTwoLanguages() throws IOException {
+        String one = "some stuff";
+        String two = "other stuff";
+        TransliterationResults t = builder()
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", one))
+                .addTransliteration(LanguageCode.AFRIKAANS, Transliteration.of("Arab", two))
+                .build();
+        assertEquals(t, throughString(t));
+
+        assertEquals(ImmutableSet.of(LanguageCode.ARABIC, LanguageCode.AFRIKAANS), t.getTransliterationResults().keySet());
+
+        assertEquals(ImmutableSet.of("Latn"), t.getTransliteration(LanguageCode.ARABIC).listScripts());
+
+        assertEquals(ImmutableSet.of("Arab"),
+                t.getTransliteration(LanguageCode.AFRIKAANS).listScripts());
+
+
+        assertEquals(one, t.getTransliterationInScript(LanguageCode.ARABIC, "Latn"));
+        assertEquals(two, t.getTransliterationInScript(LanguageCode.AFRIKAANS, "Arab"));
+
+    }
+
+}

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/TransliterationResultsTest.java
@@ -66,7 +66,7 @@ public class TransliterationResultsTest {
                 .build();
         assertEquals(t, throughString(t));
 
-        assertEquals(ImmutableSet.of(LanguageCode.ARABIC), t.getTransliterationResults().keySet());
+        assertEquals(ImmutableSet.of(LanguageCode.ARABIC), t.getResults().keySet());
 
         assertEquals(ImmutableSet.of("Latn", "Arab"),
                 t.getTransliteration(LanguageCode.ARABIC).listScripts());
@@ -86,7 +86,7 @@ public class TransliterationResultsTest {
                 .build();
         assertEquals(t, throughString(t));
 
-        assertEquals(ImmutableSet.of(LanguageCode.ARABIC, LanguageCode.AFRIKAANS), t.getTransliterationResults().keySet());
+        assertEquals(ImmutableSet.of(LanguageCode.ARABIC, LanguageCode.AFRIKAANS), t.getResults().keySet());
 
         assertEquals(ImmutableSet.of("Latn"), t.getTransliteration(LanguageCode.ARABIC).listScripts());
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,12 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-model</artifactId>
     <name>adm-model</name>
-    <version>2.3.102</version>
+    <version>2.3.104-SNAPSHOT</version>
     <description>ADM data model.</description>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.102</version>
+        <version>2.3.104-SNAPSHOT</version>
     </parent>
     <build>
         <resources>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,12 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-model</artifactId>
     <name>adm-model</name>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.100</version>
     <description>ADM data model.</description>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.100</version>
     </parent>
     <build>
         <resources>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,12 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-model</artifactId>
     <name>adm-model</name>
-    <version>2.3.100</version>
+    <version>2.3.102</version>
     <description>ADM data model.</description>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.100</version>
+        <version>2.3.102</version>
     </parent>
     <build>
         <resources>

--- a/model/src/main/java/com/basistech/rosette/dm/AnnotatedText.java
+++ b/model/src/main/java/com/basistech/rosette/dm/AnnotatedText.java
@@ -536,6 +536,11 @@ public class AnnotatedText implements Serializable {
     public ListAttribute<Keyphrase> getKeyphrases() {
         return (ListAttribute<Keyphrase>) attributes.get(AttributeKey.KEYPHRASE.key());
     }
+
+    public TransliterationResults getTransliteration() {
+        return (TransliterationResults) attributes.get(AttributeKey.TRANSLITERATION.key());
+    }
+
     /**
      * toString is a convenience for accessing the textual data, if any, in this annotated text.
      * @return the data for this AnnotatedText as a String.
@@ -814,6 +819,11 @@ public class AnnotatedText implements Serializable {
 
         public Builder keyphrases(ListAttribute<Keyphrase> keyphrases) {
             attributes.put(AttributeKey.KEYPHRASE.key(), keyphrases);
+            return this;
+        }
+
+        public Builder transliteration(TransliterationResults transliterationResults) {
+            attributes.put(AttributeKey.TRANSLITERATION.key(), transliterationResults);
             return this;
         }
 

--- a/model/src/main/java/com/basistech/rosette/dm/AttributeKey.java
+++ b/model/src/main/java/com/basistech/rosette/dm/AttributeKey.java
@@ -53,7 +53,9 @@ enum AttributeKey {
     TOPIC_RESULTS("topicResults"),
 
     CONCEPT("concepts"),
-    KEYPHRASE("keyphrases");
+    KEYPHRASE("keyphrases"),
+
+    TRANSLITERATION("transliteration");
 
     private final String key;
 

--- a/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
+++ b/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
@@ -1,0 +1,202 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.basistech.rosette.dm;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class Transliteration extends BaseAttribute {
+
+    private Map<String, String> scriptMap;
+
+    protected Transliteration(Map<String, String> scriptMap,
+                              Map<String, Object> extendedAttributes) {
+        super(extendedAttributes);
+        this.scriptMap = ImmutableMap.copyOf(scriptMap);
+    }
+
+    /**
+     * Gets the transliterated text in the given script
+     * @param script The script to look for.
+     * @return The transliterated text, or {@code null} if no mapping was found.
+     */
+    public String getWithScript(String script) {
+        return scriptMap.get(script);
+    }
+
+    /**
+     * Convinience method to create a transliteration with the given script and value.
+     * @param script The script the transliteration is in
+     * @param value The transliterated text.
+     * @return A newly built immutable Transliteration containing the given transliterated text
+     */
+    public static Transliteration of(String script, String value) {
+        return Builder.of(script, value).build();
+    }
+
+    /**
+     * Lists all the scripts this transliteration has text for.
+     * @return An immutable set of all the scripts.
+     */
+    public Set<String> listScripts() {
+        return ImmutableSet.copyOf(scriptMap.keySet());
+    }
+
+    /**
+     * Gives all the mappings that this transliteration has.
+     * @return An immutable map containing the transliterations
+     */
+    public Map<String, String> getAllTransliterations() {
+        return scriptMap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        Transliteration that = (Transliteration) o;
+
+        return scriptMap != null ? scriptMap.equals(that.scriptMap) : that.scriptMap == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (scriptMap != null ? scriptMap.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public Objects.ToStringHelper toStringHelper() {
+        return Objects.toStringHelper(this)
+                .add("scriptMap", scriptMap);
+    }
+
+    public static final class Builder extends BaseAttribute.Builder<Transliteration, Transliteration.Builder> {
+        private Map<String, String> scriptMap;
+
+        /**
+         * Creates a builder with the given transliteration text, and script pair.
+         * @param script The script.
+         * @param value The transliterated text.
+         */
+        public Builder(String script, String value) {
+            scriptMap = new HashMap<>();
+            scriptMap.put(script, value);
+        }
+
+        /**
+         * Creates a builder that starts out with the same transliterations as the given {@link Transliteration}.
+         * @param other The transliteration to base off of.
+         */
+        public Builder(Transliteration other) {
+            scriptMap = new HashMap<>(other.scriptMap);
+        }
+
+        /**
+         * Creates a builder without any transliterated text.
+         */
+        public Builder() {
+            scriptMap = new HashMap<>();
+        }
+
+        /**
+         * Adds a transliterated text to this builder.
+         * @param script The script of the transliteration.
+         * @param value The transliterated text itself.
+         * @return {@code this}.
+         */
+        public Builder addTransliteration(String script, String value) {
+            scriptMap.put(script, value);
+            return this;
+        }
+
+        /**
+         * Adds all the transliterations within the given {@link Transliteration} to this builder.
+         * @param transliteration The transliteration.
+         * @return {@code this}.
+         */
+        public Builder addTransliterations(Transliteration transliteration) {
+            scriptMap.putAll(transliteration.scriptMap);
+            return this;
+        }
+
+        /**
+         * Clears all the transliterated texts within the current builder.
+         * @return {@code this}.
+         */
+        public Builder clearTransliterations() {
+            scriptMap.clear();
+            return this;
+        }
+
+        /**
+         * Sets the internal script to transliterated text mapping to a copy of the given map.
+         * @param forLang The map to copy.
+         */
+        public void transliterations(Map<String, String> forLang) {
+            scriptMap = new HashMap<>(forLang);
+        }
+
+        /**
+         * Creates a new builder with a transliterated text under the given script.
+         * @param script The script.
+         * @param transliteration The transliterated text.
+         * @return A builder that starts with the given mapping.
+         */
+        public static Builder of(String script, String transliteration) {
+            return new Builder(script, transliteration);
+        }
+
+        /**
+         * Creates a builder whose contents are a copy of the given {@link Transliteration}.
+         * @param transliteration The transliteration to copy.
+         * @return A new builder that starts out the same as the given transliteration.
+         */
+        public static Builder of(Transliteration transliteration) {
+            return new Builder(transliteration);
+        }
+
+        /**
+         * Creates a new {@link Transliteration} from the current state of this builder.
+         * @return The newly created {@link Transliteration}
+         */
+        public Transliteration build() {
+            return new Transliteration(scriptMap, buildExtendedProperties());
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+
+    }
+}

--- a/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
+++ b/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public final class Transliteration extends BaseAttribute {
     }
 
     /**
-     * Convinience method to create a transliteration with the given script and value.
+     * Convenience method to create a transliteration with the given script and value.
      * @param script The script the transliteration is in
      * @param value The transliterated text.
      * @return A newly built immutable Transliteration containing the given transliterated text
@@ -163,8 +163,9 @@ public final class Transliteration extends BaseAttribute {
          * Sets the internal script to transliterated text mapping to a copy of the given map.
          * @param forLang The map to copy.
          */
-        public void transliterations(Map<ISO15924, String> forLang) {
+        public Builder transliterations(Map<ISO15924, String> forLang) {
             scriptMap = new HashMap<>(forLang);
+            return this;
         }
 
         /**

--- a/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
+++ b/model/src/main/java/com/basistech/rosette/dm/Transliteration.java
@@ -15,6 +15,7 @@
 */
 package com.basistech.rosette.dm;
 
+import com.basistech.util.ISO15924;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -25,9 +26,9 @@ import java.util.Set;
 
 public final class Transliteration extends BaseAttribute {
 
-    private Map<String, String> scriptMap;
+    private Map<ISO15924, String> scriptMap;
 
-    protected Transliteration(Map<String, String> scriptMap,
+    protected Transliteration(Map<ISO15924, String> scriptMap,
                               Map<String, Object> extendedAttributes) {
         super(extendedAttributes);
         this.scriptMap = ImmutableMap.copyOf(scriptMap);
@@ -38,7 +39,7 @@ public final class Transliteration extends BaseAttribute {
      * @param script The script to look for.
      * @return The transliterated text, or {@code null} if no mapping was found.
      */
-    public String getWithScript(String script) {
+    public String get(ISO15924 script) {
         return scriptMap.get(script);
     }
 
@@ -48,7 +49,7 @@ public final class Transliteration extends BaseAttribute {
      * @param value The transliterated text.
      * @return A newly built immutable Transliteration containing the given transliterated text
      */
-    public static Transliteration of(String script, String value) {
+    public static Transliteration of(ISO15924 script, String value) {
         return Builder.of(script, value).build();
     }
 
@@ -56,7 +57,7 @@ public final class Transliteration extends BaseAttribute {
      * Lists all the scripts this transliteration has text for.
      * @return An immutable set of all the scripts.
      */
-    public Set<String> listScripts() {
+    public Set<ISO15924> listScripts() {
         return ImmutableSet.copyOf(scriptMap.keySet());
     }
 
@@ -64,7 +65,7 @@ public final class Transliteration extends BaseAttribute {
      * Gives all the mappings that this transliteration has.
      * @return An immutable map containing the transliterations
      */
-    public Map<String, String> getAllTransliterations() {
+    public Map<ISO15924, String> getAll() {
         return scriptMap;
     }
 
@@ -101,14 +102,14 @@ public final class Transliteration extends BaseAttribute {
     }
 
     public static final class Builder extends BaseAttribute.Builder<Transliteration, Transliteration.Builder> {
-        private Map<String, String> scriptMap;
+        private Map<ISO15924, String> scriptMap;
 
         /**
          * Creates a builder with the given transliteration text, and script pair.
          * @param script The script.
          * @param value The transliterated text.
          */
-        public Builder(String script, String value) {
+        public Builder(ISO15924 script, String value) {
             scriptMap = new HashMap<>();
             scriptMap.put(script, value);
         }
@@ -134,7 +135,7 @@ public final class Transliteration extends BaseAttribute {
          * @param value The transliterated text itself.
          * @return {@code this}.
          */
-        public Builder addTransliteration(String script, String value) {
+        public Builder add(ISO15924 script, String value) {
             scriptMap.put(script, value);
             return this;
         }
@@ -144,7 +145,7 @@ public final class Transliteration extends BaseAttribute {
          * @param transliteration The transliteration.
          * @return {@code this}.
          */
-        public Builder addTransliterations(Transliteration transliteration) {
+        public Builder add(Transliteration transliteration) {
             scriptMap.putAll(transliteration.scriptMap);
             return this;
         }
@@ -162,7 +163,7 @@ public final class Transliteration extends BaseAttribute {
          * Sets the internal script to transliterated text mapping to a copy of the given map.
          * @param forLang The map to copy.
          */
-        public void transliterations(Map<String, String> forLang) {
+        public void transliterations(Map<ISO15924, String> forLang) {
             scriptMap = new HashMap<>(forLang);
         }
 
@@ -172,7 +173,7 @@ public final class Transliteration extends BaseAttribute {
          * @param transliteration The transliterated text.
          * @return A builder that starts with the given mapping.
          */
-        public static Builder of(String script, String transliteration) {
+        public static Builder of(ISO15924 script, String transliteration) {
             return new Builder(script, transliteration);
         }
 

--- a/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
@@ -16,6 +16,7 @@
 
 package com.basistech.rosette.dm;
 
+import com.basistech.util.ISO15924;
 import com.basistech.util.LanguageCode;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
@@ -62,12 +63,12 @@ public final class TransliterationResults extends BaseAttribute {
      * @param script The script to check
      * @return The transliteration, or null if one doesn't exist matching the given criteria.
      */
-    public String getTransliterationInScript(LanguageCode code, String script) {
+    public String getTransliterationInScript(LanguageCode code, ISO15924 script) {
         Transliteration t = getTransliteration(code);
         if (t == null) {
             return null;
         } else {
-            return t.getWithScript(script);
+            return t.get(script);
         }
     }
 
@@ -118,7 +119,7 @@ public final class TransliterationResults extends BaseAttribute {
          * @param script The script for the new transliteration.
          * @param transliteration The text for the new transliteration.
          */
-        public Builder(LanguageCode languageCode, String script, String transliteration) {
+        public Builder(LanguageCode languageCode, ISO15924 script, String transliteration) {
             this.results = new HashMap<>();
             results.put(languageCode, Transliteration.Builder.of(script, transliteration));
 
@@ -161,7 +162,7 @@ public final class TransliterationResults extends BaseAttribute {
          */
         public Builder addTransliteration(LanguageCode languageCode, Transliteration transliteration) {
             if (results.containsKey(languageCode)) {
-                results.get(languageCode).addTransliterations(transliteration);
+                results.get(languageCode).add(transliteration);
             } else {
                 results.put(languageCode, Transliteration.Builder.of(transliteration));
             }

--- a/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2017 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
@@ -1,0 +1,208 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.dm;
+
+import com.basistech.util.LanguageCode;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class TransliterationResults extends BaseAttribute {
+
+    private final Map<LanguageCode, Transliteration> transliterationResults;
+
+    protected TransliterationResults(Map<LanguageCode, Transliteration> results,
+                                     Map<String, Object> extendedAttributes) {
+
+        super(extendedAttributes);
+        ImmutableMap.Builder<LanguageCode, Transliteration> mapBuilder = ImmutableMap.builder();
+        for (LanguageCode lc : results.keySet()) {
+            mapBuilder.put(lc, results.get(lc));
+        }
+        this.transliterationResults = mapBuilder.build();
+    }
+
+    /**
+     * Gets all the {@link Transliteration}s inside {@code this}
+     * @return An immutable view of the transliterations.
+     */
+    public Map<LanguageCode, Transliteration> getTransliterationResults() {
+        // This is immutable
+        return transliterationResults;
+    }
+
+    /**
+     * Gets the {@link Transliteration} for the given {@link LanguageCode}.
+     * @param code The code to check
+     * @return The transliteration, or {@code null} if there isn't one with the given language code.
+     */
+    public Transliteration getTransliteration(LanguageCode code) {
+        return getTransliterationResults().get(code);
+    }
+
+    /**
+     * Gets the actual transliteration for the given {@link LanguageCode} in the given {@code script}
+     * @param code The language code to check
+     * @param script The script to check
+     * @return The transliteration, or null if one doesn't exist matching the given criteria.
+     */
+    public String getTransliterationInScript(LanguageCode code, String script) {
+        Transliteration t = getTransliteration(code);
+        if (t == null) {
+            return null;
+        } else {
+            return t.getWithScript(script);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        TransliterationResults that = (TransliterationResults) o;
+
+        return transliterationResults != null
+                ? transliterationResults.equals(that.transliterationResults) : that.transliterationResults == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (transliterationResults != null ? transliterationResults.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public Objects.ToStringHelper toStringHelper() {
+        return Objects.toStringHelper(this)
+                .add("transliterationResults", transliterationResults);
+    }
+
+    /**
+     * Builder for immutable {@link TransliterationResults}
+     */
+    public static class Builder extends BaseAttribute.Builder<TransliterationResults, TransliterationResults.Builder> {
+
+        private Map<LanguageCode, Transliteration.Builder> results;
+
+        /**
+         * Creates a new builder with a {@link Transliteration} containing the given transliteration under the
+         * language {@code languageCode}
+         * @param languageCode The language code to put the new transliteration under.
+         * @param script The script for the new transliteration.
+         * @param transliteration The text for the new transliteration.
+         */
+        public Builder(LanguageCode languageCode, String script, String transliteration) {
+            this.results = new HashMap<>();
+            results.put(languageCode, Transliteration.Builder.of(script, transliteration));
+
+        }
+
+        /**
+         * Creates a new empty builder (one with no {@link Transliteration}s)
+         */
+        public Builder() {
+            results = new HashMap<>();
+        }
+
+        /**
+         * Creates a new builder whose state starts out with a copy of the given {@link TransliterationResults}
+         * @param other The transliteration to start from.
+         */
+        public Builder(TransliterationResults other) {
+            results = copy(other.transliterationResults);
+        }
+
+        /**
+         * Creates a copy of the given map, all {@link Transliteration}s are converted to
+         * {@link Transliteration.Builder}s so that they can be modified during the use of this builder.
+         * @param otherResults The map to copy
+         * @return The copied map
+         */
+        private Map<LanguageCode, Transliteration.Builder> copy(Map<LanguageCode, Transliteration> otherResults) {
+            Map<LanguageCode, Transliteration.Builder> output = new HashMap<>(otherResults.size());
+            for (LanguageCode lang : otherResults.keySet()) {
+                output.put(lang, Transliteration.Builder.of(otherResults.get(lang)));
+            }
+            return output;
+        }
+
+        /**
+         * Adds the given {@link Transliteration} under the given {@link LanguageCode}
+         * @param languageCode The language code to add under
+         * @param transliteration The transliteration to add
+         * @return {@code this}
+         */
+        public Builder addTransliteration(LanguageCode languageCode, Transliteration transliteration) {
+            if (results.containsKey(languageCode)) {
+                results.get(languageCode).addTransliterations(transliteration);
+            } else {
+                results.put(languageCode, Transliteration.Builder.of(transliteration));
+            }
+            return this;
+        }
+
+        /**
+         * Sets this builder's internal transliterations mapping to a copy of the given one.
+         * @param transliterations The new transliterations
+         * @return {@code this}
+         */
+        public Builder transliteration(Map<LanguageCode, Transliteration> transliterations) {
+            this.results = copy(transliterations);
+            return this;
+        }
+
+        /**
+         * Clears the current transliterations for all languages
+         * @return this
+         */
+        public Builder clearResults() {
+            results.clear();
+            return this;
+        }
+
+        /**
+         * Creates a new immutable {@link TransliterationResults} from the internal state of this builder.
+         * @return The new {@link TransliterationResults}
+         */
+        public TransliterationResults build() {
+            Map<LanguageCode, Transliteration> finalResults = new HashMap<>();
+            for (LanguageCode l : results.keySet()) {
+                finalResults.put(l, results.get(l).build());
+            }
+            return new TransliterationResults(finalResults, buildExtendedProperties());
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+    }
+
+}

--- a/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TransliterationResults.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public final class TransliterationResults extends BaseAttribute {
 
-    private final Map<LanguageCode, Transliteration> transliterationResults;
+    private final Map<LanguageCode, Transliteration> results;
 
     protected TransliterationResults(Map<LanguageCode, Transliteration> results,
                                      Map<String, Object> extendedAttributes) {
@@ -35,16 +35,16 @@ public final class TransliterationResults extends BaseAttribute {
         for (LanguageCode lc : results.keySet()) {
             mapBuilder.put(lc, results.get(lc));
         }
-        this.transliterationResults = mapBuilder.build();
+        this.results = mapBuilder.build();
     }
 
     /**
      * Gets all the {@link Transliteration}s inside {@code this}
      * @return An immutable view of the transliterations.
      */
-    public Map<LanguageCode, Transliteration> getTransliterationResults() {
+    public Map<LanguageCode, Transliteration> getResults() {
         // This is immutable
-        return transliterationResults;
+        return results;
     }
 
     /**
@@ -53,7 +53,7 @@ public final class TransliterationResults extends BaseAttribute {
      * @return The transliteration, or {@code null} if there isn't one with the given language code.
      */
     public Transliteration getTransliteration(LanguageCode code) {
-        return getTransliterationResults().get(code);
+        return getResults().get(code);
     }
 
     /**
@@ -87,21 +87,21 @@ public final class TransliterationResults extends BaseAttribute {
 
         TransliterationResults that = (TransliterationResults) o;
 
-        return transliterationResults != null
-                ? transliterationResults.equals(that.transliterationResults) : that.transliterationResults == null;
+        return results != null
+                ? results.equals(that.results) : that.results == null;
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (transliterationResults != null ? transliterationResults.hashCode() : 0);
+        result = 31 * result + (results != null ? results.hashCode() : 0);
         return result;
     }
 
     @Override
     public Objects.ToStringHelper toStringHelper() {
         return Objects.toStringHelper(this)
-                .add("transliterationResults", transliterationResults);
+                .add("results", results);
     }
 
     /**
@@ -136,7 +136,7 @@ public final class TransliterationResults extends BaseAttribute {
          * @param other The transliteration to start from.
          */
         public Builder(TransliterationResults other) {
-            results = copy(other.transliterationResults);
+            results = copy(other.results);
         }
 
         /**

--- a/model/src/test/java/com/basistech/rosette/dm/EqualsTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/EqualsTest.java
@@ -487,6 +487,49 @@ public class EqualsTest {
 
     }
 
+    @Test
+    public void transliteration() throws Exception {
+        TransliterationResults t1 = new TransliterationResults.Builder()
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "one"))
+                .build();
+
+        TransliterationResults t2 = new TransliterationResults.Builder()
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "one"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Arab", "one"))
+                .build();
+
+        TransliterationResults t3 = new TransliterationResults.Builder()
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "on3"))
+                .build();
+
+        TransliterationResults t4 = new TransliterationResults.Builder()
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", "one"))
+                .build();
+
+        TransliterationResults t5 = new TransliterationResults.Builder()
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Arab", "one"))
+                .build();
+
+        // All different
+        assertFalse(t1.equals(t2));
+        assertFalse(t1.equals(t3));
+        assertFalse(t1.equals(t4));
+        assertFalse(t1.equals(t5));
+        assertFalse(t2.equals(t3));
+        assertFalse(t2.equals(t4));
+        assertFalse(t2.equals(t5));
+        assertFalse(t3.equals(t4));
+        assertFalse(t3.equals(t5));
+        assertFalse(t4.equals(t5));
+
+        // All the same
+        assertTrue(t1.equals(t1));
+        assertTrue(t2.equals(t2));
+        assertTrue(t3.equals(t3));
+        assertTrue(t4.equals(t4));
+        assertTrue(t5.equals(t5));
+    }
+
 
 
 }

--- a/model/src/test/java/com/basistech/rosette/dm/EqualsTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/EqualsTest.java
@@ -490,24 +490,24 @@ public class EqualsTest {
     @Test
     public void transliteration() throws Exception {
         TransliterationResults t1 = new TransliterationResults.Builder()
-                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "one"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of(ISO15924.Latn, "one"))
                 .build();
 
         TransliterationResults t2 = new TransliterationResults.Builder()
-                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "one"))
-                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Arab", "one"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of(ISO15924.Latn, "one"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of(ISO15924.Arab, "one"))
                 .build();
 
         TransliterationResults t3 = new TransliterationResults.Builder()
-                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Latn", "on3"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of(ISO15924.Latn, "on3"))
                 .build();
 
         TransliterationResults t4 = new TransliterationResults.Builder()
-                .addTransliteration(LanguageCode.ARABIC, Transliteration.of("Latn", "one"))
+                .addTransliteration(LanguageCode.ARABIC, Transliteration.of(ISO15924.Latn, "one"))
                 .build();
 
         TransliterationResults t5 = new TransliterationResults.Builder()
-                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of("Arab", "one"))
+                .addTransliteration(LanguageCode.ENGLISH, Transliteration.of(ISO15924.Arab, "one"))
                 .build();
 
         // All different

--- a/pom.xml
+++ b/pom.xml
@@ -136,4 +136,24 @@
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>internal-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-plugin-version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>basistech.repo</serverId>
+                            <nexusUrl>http://nexus.basistech.net:8081/nexus/</nexusUrl>
+                            <stagingProfileId>1dd11ca8866422</stagingProfileId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>annotated-data-model</artifactId>
-    <version>2.3.100</version>
+    <version>2.3.102</version>
     <packaging>pom</packaging>
     <parent>
         <artifactId>open-source-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>annotated-data-model</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.100</version>
     <packaging>pom</packaging>
     <parent>
         <artifactId>open-source-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>annotated-data-model</artifactId>
-    <version>2.3.102</version>
+    <version>2.3.104-SNAPSHOT</version>
     <packaging>pom</packaging>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
         <version>1.1.0</version>
     </parent>
+
     <description>
       Data model for text and its annotations.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
   Copyright 2015 Basis Technology Corp.
- 
+
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
- 
+
          http://www.apache.org/licenses/LICENSE-2.0
- 
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
-        <version>1.1.0</version>
+        <version>1.1.2</version>
     </parent>
 
     <description>
@@ -137,24 +137,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <profiles>
-        <profile>
-            <id>internal-release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-plugin-version}</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>basistech.repo</serverId>
-                            <nexusUrl>http://nexus.basistech.net:8081/nexus/</nexusUrl>
-                            <stagingProfileId>1dd11ca8866422</stagingProfileId>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-taglets</artifactId>
     <name>adm-taglets</name>
-    <version>2.3.100</version>
+    <version>2.3.102</version>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.100</version>
+        <version>2.3.102</version>
     </parent>
     <dependencies>
         <dependency>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-taglets</artifactId>
     <name>adm-taglets</name>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.100</version>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.100</version>
     </parent>
     <dependencies>
         <dependency>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>adm-taglets</artifactId>
     <name>adm-taglets</name>
-    <version>2.3.102</version>
+    <version>2.3.104-SNAPSHOT</version>
     <parent>
         <groupId>com.basistech</groupId>
         <artifactId>annotated-data-model</artifactId>
-        <version>2.3.102</version>
+        <version>2.3.104-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
…nd Transliteration to hold transliterations based on scripts. Serialized as a plain Map<String, Map<String, String>>. Implemented tests for new attribute.