### PR TITLE
ETROG-3126: Ignore null attribute values in AnnotatedText

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,15 @@
 # Cumulative Release Notes for the Annotated Data Model
 
+## Unreleased
+
+### [ETROG-3126](https://basistech.atlassian.net/browse/ETROG-3126) Analyze foreign tokens within Russian as English
+
+Ignore null attribute values in the constructor of `AnnotatedText`.
+Previously, it would throw a `NullPointerException`.
+
 ## 2.5.4
 
-### [COMN-254](https://basistech.atlassian.net.browse/COMN-254) Fix lossy copy constructor
+### [COMN-254](https://basistech.atlassian.net/browse/COMN-254) Fix lossy copy constructor
 
 Fixed `ArabicMorphoAnalysis.Builder`'s copy constructor so it copies all data.
 

--- a/model/src/main/java/com/basistech/rosette/dm/AnnotatedText.java
+++ b/model/src/main/java/com/basistech/rosette/dm/AnnotatedText.java
@@ -96,7 +96,8 @@ public class AnnotatedText implements Serializable {
         ListAttribute<Entity> sourceEntityList = (ListAttribute<Entity>) attributes.get(AttributeKey.ENTITY.key());
 
         for (Map.Entry<String, BaseAttribute> me : attributes.entrySet()) {
-            if (!AttributeKey.RESOLVED_ENTITY.key().equals(me.getKey())
+            if (me.getValue() != null
+                && !AttributeKey.RESOLVED_ENTITY.key().equals(me.getKey())
                 && !AttributeKey.ENTITY_MENTION.key().equals(me.getKey())
                     // defer entity
                 && !AttributeKey.ENTITY.key().equals(me.getKey())) {


### PR DESCRIPTION
The accuracy test runner assumes the test data includes script regions, but the new Russian corpus doesn’t, so the test runner ends up trying to build an `AnnotatedText` with a null script region.