### PR TITLE
RLPNC-7169 TranslatedData contains source and target domains

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Cumulative Release Notes for the Annotated Data Model
 
+## 2.10.0
+[RLPNC-7169](https://basistech.atlassian.net/browse/RLPNC-7169) `TranslatedData` now holds source domain. `domain` is renamed to `targetDomain`
+
+`TranslatedData#getDomain` is marked for removal as well as
+the constructors which don't require `sourceDomain` to be specified.
+
 ## 2.9.0
 
 ### [COMN-301](https://basistech.atlassian.net/browse/COMN-301) Release new parent POMs for 2023 Q3

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TranslatedDataMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TranslatedDataMixin.java
@@ -26,7 +26,10 @@ import java.util.Map;
  */
 public abstract class TranslatedDataMixin {
     @JsonCreator
-    TranslatedDataMixin(@JsonProperty("domain") TextDomain domain,
+    TranslatedDataMixin(
+                        @JsonProperty("sourceDomain") TextDomain sourceDomain,
+                        @JsonProperty("targetDomain") TextDomain targetDomain,
+                        @JsonProperty("domain") TextDomain domain,
                         @JsonProperty("translation") String translation,
                         @JsonProperty("confidence") Double confidence,
                         @JsonProperty("extendedProperties") Map<String, Object> extendedProperties) {

--- a/json/src/main/java/com/basistech/rosette/dm/jackson/TranslatedDataMixin.java
+++ b/json/src/main/java/com/basistech/rosette/dm/jackson/TranslatedDataMixin.java
@@ -16,6 +16,8 @@
 package com.basistech.rosette.dm.jackson;
 
 import com.basistech.util.TextDomain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -28,8 +30,8 @@ public abstract class TranslatedDataMixin {
     @JsonCreator
     TranslatedDataMixin(
                         @JsonProperty("sourceDomain") TextDomain sourceDomain,
-                        @JsonProperty("targetDomain") TextDomain targetDomain,
-                        @JsonProperty("domain") TextDomain domain,
+                        // TODO: remove @JsonAlias("domain") when TranslatedData.domain is removed
+                        @JsonProperty("targetDomain") @JsonAlias("domain") TextDomain targetDomain,
                         @JsonProperty("translation") String translation,
                         @JsonProperty("confidence") Double confidence,
                         @JsonProperty("extendedProperties") Map<String, Object> extendedProperties) {

--- a/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
@@ -248,7 +248,7 @@ public class JsonTest extends AdmAssert {
 
         TextDomain germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         TextDomain spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);

--- a/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/array/JsonTest.java
@@ -248,12 +248,12 @@ public class JsonTest extends AdmAssert {
 
         TextDomain germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         TextDomain spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
         String spanishText = "Uno.  Dos.";
-        tdBuilder = new TranslatedData.Builder(spanishDomain, spanishText);
+        tdBuilder = new TranslatedData.Builder(germanDomain, spanishDomain, spanishText);
         spanishTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(spanishTranslatedData);
         builder.translatedData(translatedDataBuilder.build());

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
@@ -260,7 +260,7 @@ public class JsonTest extends AdmAssert {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
@@ -505,7 +505,7 @@ public class JsonTest extends AdmAssert {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);

--- a/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
+++ b/json/src/test/java/com/basistech/rosette/dm/json/plain/JsonTest.java
@@ -260,12 +260,12 @@ public class JsonTest extends AdmAssert {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
         String spanishText = "Uno.  Dos.";
-        tdBuilder = new TranslatedData.Builder(spanishDomain, spanishText);
+        tdBuilder = new TranslatedData.Builder(germanDomain, spanishDomain, spanishText);
         spanishTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(spanishTranslatedData);
         builder.translatedData(translatedDataBuilder.build());
@@ -505,12 +505,12 @@ public class JsonTest extends AdmAssert {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
         String spanishText = "Uno.  Dos.";
-        tdBuilder = new TranslatedData.Builder(spanishDomain, spanishText);
+        tdBuilder = new TranslatedData.Builder(germanDomain, spanishDomain, spanishText);
         spanishTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(spanishTranslatedData);
         builder.translatedData(translatedDataBuilder.build());

--- a/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
@@ -31,33 +31,23 @@ import java.util.Map;
 public class TranslatedData extends BaseAttribute implements Serializable {
     private static final long serialVersionUID = 250L;
     private final TextDomain sourceDomain;
-
-    /**
-     * @deprecated Replaced by targetDomain
-     */
-    @Deprecated(forRemoval = true)
-    private final TextDomain domain;
     private final TextDomain targetDomain;
     private final String translation;
     private final Double confidence;
 
+
+    /**
+     * @deprecated sourceDomain should be specified
+     */
+    @Deprecated(forRemoval = true)
     protected TranslatedData(TextDomain targetDomain, String translation, Double confidence, Map<String, Object> extendedProperties) {
-        this(null, targetDomain, targetDomain, translation, confidence, extendedProperties);
+        this(null, targetDomain, translation, confidence, extendedProperties);
     }
 
     protected TranslatedData(TextDomain sourceDomain, TextDomain targetDomain, String translation, Double confidence, Map<String, Object> extendedProperties) {
-        this(sourceDomain, targetDomain, targetDomain, translation, confidence, extendedProperties);
-    }
-
-    /**
-     * @deprecated should be removed when {@link TranslatedData#domain} is removed
-     */
-    @Deprecated(forRemoval = true)
-    protected TranslatedData(TextDomain sourceDomain, TextDomain targetDomain, TextDomain domain, String translation, Double confidence, Map<String, Object> extendedProperties) {
         super(extendedProperties);
         this.sourceDomain = sourceDomain;
         this.targetDomain = targetDomain;
-        this.domain = domain;
         this.translation = translation;
         this.confidence = confidence;
     }
@@ -77,7 +67,7 @@ public class TranslatedData extends BaseAttribute implements Serializable {
      */
     @Deprecated(forRemoval = true)
     public TextDomain getDomain() {
-        return domain;
+        return targetDomain;
     }
 
     /**
@@ -107,8 +97,10 @@ public class TranslatedData extends BaseAttribute implements Serializable {
 
     @Override
     protected MoreObjects.ToStringHelper toStringHelper() {
+        // FIXME: targetDomain and sourceDomain is not represented in the output
+        //  but domain is, though it is deprecated.
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
-                .add("domain", domain)
+                .add("domain", targetDomain)
                 .add("translation", translation);
         if (confidence != null) {
             helper.add("confidence", confidence);

--- a/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
@@ -97,10 +97,9 @@ public class TranslatedData extends BaseAttribute implements Serializable {
 
     @Override
     protected MoreObjects.ToStringHelper toStringHelper() {
-        // FIXME: targetDomain and sourceDomain is not represented in the output
-        //  but domain is, though it is deprecated.
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
-                .add("domain", targetDomain)
+                .add("sourceDomain", sourceDomain)
+                .add("targetDomain", targetDomain)
                 .add("translation", translation);
         if (confidence != null) {
             helper.add("confidence", confidence);

--- a/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
@@ -41,6 +41,10 @@ public class TranslatedData extends BaseAttribute implements Serializable {
     private final String translation;
     private final Double confidence;
 
+    protected TranslatedData(TextDomain targetDomain, String translation, Double confidence, Map<String, Object> extendedProperties) {
+        this(null, targetDomain, targetDomain, translation, confidence, extendedProperties);
+    }
+
     protected TranslatedData(TextDomain sourceDomain, TextDomain targetDomain, String translation, Double confidence, Map<String, Object> extendedProperties) {
         this(sourceDomain, targetDomain, targetDomain, translation, confidence, extendedProperties);
     }
@@ -124,6 +128,19 @@ public class TranslatedData extends BaseAttribute implements Serializable {
         /**
          * Constructs a builder from the required properties
          *
+         * @param targetDomain specifies the language and script of the translation
+         * @param translation the translation for the text
+         */
+        public Builder(TextDomain targetDomain, String translation) {
+            this.sourceDomain = null;
+            this.targetDomain = targetDomain;
+            this.translation = translation;
+        }
+
+        /**
+         * Constructs a builder from the required properties
+         *
+         * @param sourceDomain specifies the language and script of the text
          * @param targetDomain specifies the language and script of the translation
          * @param translation the translation for the text
          */

--- a/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
@@ -30,25 +30,58 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 public class TranslatedData extends BaseAttribute implements Serializable {
     private static final long serialVersionUID = 250L;
+    private final TextDomain sourceDomain;
+
+    /**
+     * @deprecated Replaced by targetDomain
+     */
+    @Deprecated(forRemoval = true)
     private final TextDomain domain;
+    private final TextDomain targetDomain;
     private final String translation;
     private final Double confidence;
 
-    protected TranslatedData(TextDomain domain, String translation, Double confidence, Map<String, Object> extendedProperties) {
+    protected TranslatedData(TextDomain sourceDomain, TextDomain targetDomain, String translation, Double confidence, Map<String, Object> extendedProperties) {
+        this(sourceDomain, targetDomain, targetDomain, translation, confidence, extendedProperties);
+    }
+
+    /**
+     * @deprecated should be removed when {@link TranslatedData#domain} is removed
+     */
+    @Deprecated(forRemoval = true)
+    protected TranslatedData(TextDomain sourceDomain, TextDomain targetDomain, TextDomain domain, String translation, Double confidence, Map<String, Object> extendedProperties) {
         super(extendedProperties);
+        this.sourceDomain = sourceDomain;
+        this.targetDomain = targetDomain;
         this.domain = domain;
         this.translation = translation;
         this.confidence = confidence;
     }
 
     /**
+     * Returns the sourceDomain for this object.
+     *
+     * @return the sourceDomain for this object
+     */
+    public TextDomain getSourceDomain() { return sourceDomain; }
+
+    /**
      * Returns the domain for this object.
      *
+     * @deprecated use targetDomain and getTargetDomain instead
      * @return the domain for this object
      */
+    @Deprecated(forRemoval = true)
     public TextDomain getDomain() {
         return domain;
     }
+
+    /**
+     * Returns the targetDomain for this object.
+     *
+     * @return the targetDomain for this object
+     */
+    public TextDomain getTargetDomain() { return targetDomain; }
 
     /**
      * Returns the translation for this object.
@@ -83,18 +116,20 @@ public class TranslatedData extends BaseAttribute implements Serializable {
      * Builder class for TranslatedData.
      */
     public static class Builder extends BaseAttribute.Builder<TranslatedData, TranslatedData.Builder> {
-        private TextDomain domain;
-        private String translation;
+        private final TextDomain sourceDomain;
+        private final TextDomain targetDomain;
+        private final String translation;
         private Double confidence;
 
         /**
          * Constructs a builder from the required properties
          *
-         * @param domain specifies the language and script of the translation
+         * @param targetDomain specifies the language and script of the translation
          * @param translation the translation for the text
          */
-        public Builder(TextDomain domain, String translation) {
-            this.domain = domain;
+        public Builder(TextDomain sourceDomain, TextDomain targetDomain, String translation) {
+            this.sourceDomain = sourceDomain;
+            this.targetDomain = targetDomain;
             this.translation = translation;
         }
 
@@ -105,7 +140,8 @@ public class TranslatedData extends BaseAttribute implements Serializable {
          */
         public Builder(TranslatedData toCopy) {
             super(toCopy);
-            this.domain = toCopy.domain;
+            this.sourceDomain = toCopy.sourceDomain;
+            this.targetDomain = toCopy.targetDomain;
             this.translation = toCopy.getTranslation();
         }
 
@@ -126,7 +162,7 @@ public class TranslatedData extends BaseAttribute implements Serializable {
          * @return a new TranslatedData object.
          */
         public TranslatedData build() {
-            return new TranslatedData(domain, translation, confidence, buildExtendedProperties());
+            return new TranslatedData(sourceDomain, targetDomain, translation, confidence, buildExtendedProperties());
         }
 
         @Override

--- a/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
+++ b/model/src/main/java/com/basistech/rosette/dm/TranslatedData.java
@@ -121,7 +121,9 @@ public class TranslatedData extends BaseAttribute implements Serializable {
          *
          * @param targetDomain specifies the language and script of the translation
          * @param translation the translation for the text
+         * @deprecated sourceDomain should become required in the future
          */
+        @Deprecated(forRemoval = true)
         public Builder(TextDomain targetDomain, String translation) {
             this.sourceDomain = null;
             this.targetDomain = targetDomain;

--- a/model/src/test/java/com/basistech/rosette/dm/AnnotatedTextTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/AnnotatedTextTest.java
@@ -72,11 +72,11 @@ public class AnnotatedTextTest {
             new ListAttribute.Builder<>(TranslatedData.class);
 
         TextDomain sourceDomain = new TextDomain(ISO15924.Latn, LanguageCode.ENGLISH, TransliterationScheme.NATIVE);
-        TextDomain domain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(sourceDomain, domain, germanText);
+        TextDomain targetDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(targetDomain, germanText);
         translatedDataBuilder.add(tdBuilder.build());
-        domain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
-        tdBuilder = new TranslatedData.Builder(sourceDomain, domain, spanishText);
+        targetDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
+        tdBuilder = new TranslatedData.Builder(sourceDomain, targetDomain, spanishText);
         translatedDataBuilder.add(tdBuilder.build());
 
         builder.translatedData(translatedDataBuilder.build());
@@ -85,27 +85,36 @@ public class AnnotatedTextTest {
         ListAttribute<TranslatedData> dataTranslations = text.getTranslatedData();
 
         TranslatedData data = dataTranslations.get(0);
-        TextDomain dataDomain = data.getTargetDomain();
-        ISO15924 script = dataDomain.getScript();
-        LanguageCode language = dataDomain.getLanguage();
-        TransliterationScheme scheme = dataDomain.getTransliterationScheme();
+        TextDomain dataSourceDomain = data.getSourceDomain();
+        TextDomain dataTargetDomain = data.getDomain();
+        ISO15924 targetDomainScript = dataTargetDomain.getScript();
+        LanguageCode targetDomainLanguage = dataTargetDomain.getLanguage();
+        TransliterationScheme targetDomainScheme = dataTargetDomain.getTransliterationScheme();
         String translation = data.getTranslation();
 
-        assertEquals(script, ISO15924.Latn);
-        assertEquals(language, LanguageCode.GERMAN);
-        assertEquals(scheme, TransliterationScheme.NATIVE);
+        assertNull(dataSourceDomain);
+        assertEquals(ISO15924.Latn, targetDomainScript);
+        assertEquals(LanguageCode.GERMAN, targetDomainLanguage);
+        assertEquals(TransliterationScheme.NATIVE, targetDomainScheme);
         assertEquals(translation, germanText);
 
         data = dataTranslations.get(1);
-        dataDomain = data.getTargetDomain();
-        script = dataDomain.getScript();
-        language = dataDomain.getLanguage();
-        scheme = dataDomain.getTransliterationScheme();
+        dataSourceDomain = data.getSourceDomain();
+        ISO15924 sourceDomainScript = dataSourceDomain.getScript();
+        LanguageCode sourceDomainLanguage = dataSourceDomain.getLanguage();
+        TransliterationScheme sourceDomainScheme = dataSourceDomain.getTransliterationScheme();
+        dataTargetDomain = data.getTargetDomain();
+        targetDomainScript = dataTargetDomain.getScript();
+        targetDomainLanguage = dataTargetDomain.getLanguage();
+        targetDomainScheme = dataTargetDomain.getTransliterationScheme();
         translation = data.getTranslation();
 
-        assertEquals(script, ISO15924.Latn);
-        assertEquals(language, LanguageCode.SPANISH);
-        assertEquals(scheme, TransliterationScheme.NATIVE);
+        assertEquals(ISO15924.Latn, sourceDomainScript);
+        assertEquals(LanguageCode.ENGLISH, sourceDomainLanguage);
+        assertEquals(TransliterationScheme.NATIVE, sourceDomainScheme);
+        assertEquals(ISO15924.Latn, targetDomainScript);
+        assertEquals(LanguageCode.SPANISH, targetDomainLanguage);
+        assertEquals(TransliterationScheme.NATIVE, targetDomainScheme);
         assertEquals(translation, spanishText);
     }
 

--- a/model/src/test/java/com/basistech/rosette/dm/AnnotatedTextTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/AnnotatedTextTest.java
@@ -71,11 +71,12 @@ public class AnnotatedTextTest {
         ListAttribute.Builder<TranslatedData> translatedDataBuilder =
             new ListAttribute.Builder<>(TranslatedData.class);
 
+        TextDomain sourceDomain = new TextDomain(ISO15924.Latn, LanguageCode.ENGLISH, TransliterationScheme.NATIVE);
         TextDomain domain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(domain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(sourceDomain, domain, germanText);
         translatedDataBuilder.add(tdBuilder.build());
         domain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
-        tdBuilder = new TranslatedData.Builder(domain, spanishText);
+        tdBuilder = new TranslatedData.Builder(sourceDomain, domain, spanishText);
         translatedDataBuilder.add(tdBuilder.build());
 
         builder.translatedData(translatedDataBuilder.build());
@@ -84,7 +85,7 @@ public class AnnotatedTextTest {
         ListAttribute<TranslatedData> dataTranslations = text.getTranslatedData();
 
         TranslatedData data = dataTranslations.get(0);
-        TextDomain dataDomain = data.getDomain();
+        TextDomain dataDomain = data.getTargetDomain();
         ISO15924 script = dataDomain.getScript();
         LanguageCode language = dataDomain.getLanguage();
         TransliterationScheme scheme = dataDomain.getTransliterationScheme();
@@ -96,7 +97,7 @@ public class AnnotatedTextTest {
         assertEquals(translation, germanText);
 
         data = dataTranslations.get(1);
-        dataDomain = data.getDomain();
+        dataDomain = data.getTargetDomain();
         script = dataDomain.getScript();
         language = dataDomain.getLanguage();
         scheme = dataDomain.getTransliterationScheme();

--- a/model/src/test/java/com/basistech/rosette/dm/SerializableTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/SerializableTest.java
@@ -218,7 +218,7 @@ public class SerializableTest {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);

--- a/model/src/test/java/com/basistech/rosette/dm/SerializableTest.java
+++ b/model/src/test/java/com/basistech/rosette/dm/SerializableTest.java
@@ -218,12 +218,12 @@ public class SerializableTest {
 
         germanDomain = new TextDomain(ISO15924.Latn, LanguageCode.GERMAN, TransliterationScheme.NATIVE);
         String germanText = "Ein.  Zwei.";
-        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanText);
+        TranslatedData.Builder tdBuilder = new TranslatedData.Builder(germanDomain, germanDomain, germanText);
         germanTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(germanTranslatedData);
         spanishDomain = new TextDomain(ISO15924.Latn, LanguageCode.SPANISH, TransliterationScheme.NATIVE);
         String spanishText = "Uno.  Dos.";
-        tdBuilder = new TranslatedData.Builder(spanishDomain, spanishText);
+        tdBuilder = new TranslatedData.Builder(germanDomain, spanishDomain, spanishText);
         spanishTranslatedData = tdBuilder.build();
         translatedDataBuilder.add(spanishTranslatedData);
         builder.translatedData(translatedDataBuilder.build());


### PR DESCRIPTION
* `TranslatedData` has 2 new fields: `sourceDomain` and `targetDomain`
* `TranslatedData.domain` is deprecated in favor of `targetDomain`